### PR TITLE
Use directive value instead arg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,11 @@ import { events } from './bus'
 const defaultPosition = 'bottom'
 
 const prepareBinding = (binding) => {
-  let { arg, modifiers, value } = binding
+  let { expression, modifiers, value } = binding
   let mods = Object.keys(modifiers || {})
 
   return {
-    name: arg,
+    name: expression,
     position: mods[0] || defaultPosition,
     value
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,12 @@ import { events } from './bus'
 const defaultPosition = 'bottom'
 
 const prepareBinding = (binding) => {
-  let { expression, modifiers, value } = binding
+  let { modifiers, value } = binding
   let mods = Object.keys(modifiers || {})
 
   return {
-    name: expression,
-    position: mods[0] || defaultPosition,
-    value
+    name: value,
+    position: mods[0] || defaultPosition
   }
 }
 


### PR DESCRIPTION
Will be more reliable and convenient to use a directive value instead of args to specify the name of the popover. For example, if we need to use the string name we can make it like so:

```html
<button v-popover="'popover-name'"></button>
<popover name="popover-name"></popover>
```

Otherwise, if we need to pass a variable then do so:

```html
<button v-popover="popover-id"></button>
<popover :name="popover-id"></popover>
```