### PR TITLE
Fix position when scrolling

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -113,7 +113,7 @@ export default {
 
           this.$nextTick(() => {
             let position = this
-              .getDrodownPosition(target, this.$refs.dropdown, direction)
+              .getDropdownPosition(target, this.$refs.dropdown, direction)
 
             this.position = {
               left: `${position.left}px`,
@@ -133,12 +133,13 @@ export default {
       }
     },
 
-    getDrodownPosition (target, dropdown, direction) {
+    getDropdownPosition (target, dropdown, direction) {
       let trRect = target.getBoundingClientRect()
       let ddRect = dropdown.getBoundingClientRect()
 
       // Position within the parent
-      let { offsetLeft, offsetTop } = target
+      let offsetLeft = trRect.left
+      let offsetTop = trRect.top
 
       // let shiftX = ddRect.width - trRect.width
       let shiftY = 0.5 * (ddRect.height + trRect.height)


### PR DESCRIPTION
Hi! Thanks for this simple but complete component!

I have issues when displaying the popover on elements inside a scrollable parent (side menu with a vertical list). The reason is that `element.offsetTop` is not recalculated on scroll, unlike `element.getBoundingClientRect().top`. Is there any reason not to use these values instead?

Thanks!