### PR TITLE
Allow dynamic position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const defaultPosition = 'bottom'
 const prepareBinding = ({ arg = '', modifiers = {}, value = {} }) => {
   let mods = Object.keys(modifiers)
   let name = typeof value === 'object' && value.name ? value.name : arg
-  let position = mods[0] || defaultPosition
+  let position = mods[0] || value.position || defaultPosition
 
   return { name, position, value }
 }


### PR DESCRIPTION
Hi again! This change allows `v-popover="{ name: 'something', position: 'left' }"` and so on.

I think this is necessary for allowing a dynamic position in a `v-for` (I believe modifiers cannot be dynamic). In my situation, I have a list of items where the popover is displayed but it falls out the screen for the top ones. Therefore, I'm using `position: 'bottom'` when `index < 3` or something similar. Demo [here](https://onsenui.github.io/theme-roller/#/) -- Click on "Customize" and then on the list items (this also shows the other PR, btw).