### PR TITLE
change the time of render dropdown

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -112,15 +112,17 @@ export default {
           this.visible = true
 
           this.$nextTick(() => {
-            let position = this
-              .getDropdownPosition(target, this.$refs.dropdown, direction)
+            this.$emit('show', event)
+            
+            setTimeout(()=> {
+              let position = this
+                .getDropdownPosition(target, this.$refs.dropdown, direction)
 
-            this.position = {
-              left: `${position.left}px`,
-              top: `${position.top}px`
-            }
-
-            this.$emit('show', { ...event, position })
+              this.position = {
+                left: `${position.left}px`,
+                top: `${position.top}px`
+              }
+            }, 0)
           })
         }
       })

--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -114,15 +114,15 @@ export default {
           this.$nextTick(() => {
             this.$emit('show', event)
             
-            setTimeout(()=> {
+            this.$nextTick(()=>{
               let position = this
                 .getDropdownPosition(target, this.$refs.dropdown, direction)
-
+                
               this.position = {
                 left: `${position.left}px`,
                 top: `${position.top}px`
               }
-            }, 0)
+            })
           })
         }
       })


### PR DESCRIPTION
> show the dropdown before `time` to get the size of dropdown;

For example,  My direction of `tooltip` is `top`.
```jsx
<tooltip />

<button v-popover:tooltip.top="'multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line multi-line '">
    Tooltip
 </button>
<button v-popover:tooltip.top="'one line'">
    Tooltip
</button>
```
In this case, the top we calculated is wrong. because the dropdown\`s slot is not updated. so, the dropdown\`s height is also wrong.

So, I create this commit 
```js
let position = this
	.getDropdownPosition(target, this.$refs.dropdown, direction)
this.position = {
	left: `${position.left}px`,
	top: `${position.top}px`
};
this.$emit('show', event);
```

```js
this.$emit('show', event);
setTimeout(()=>{
	let position = this
		.getDropdownPosition(target, this.$refs.dropdown, direction)
	this.position = {
		left: `${position.left}px`,
		top: `${position.top}px`
	};
},0)
```