### PR TITLE
fixed the bug when the target has descendants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const addClickEventListener = (target, params) => {
 }
 
 const addHoverEventListener = (target, params) => {
-  const mouseover = (srcEvent) => {
+  const mouseenter = (srcEvent) => {
     events.$emit('show:hover', { ...params, target, srcEvent })
   }
 
@@ -41,11 +41,11 @@ const addHoverEventListener = (target, params) => {
     events.$emit('hide:hover', { ...params, target, srcEvent })
   }
 
-  target.addEventListener('mouseover', mouseover)
+  target.addEventListener('mouseenter', mouseenter)
   target.addEventListener('mouseleave', mouseleave)
 
   target.$popoverRemoveHoverHandlers = () => {
-    target.removeEventListener('mouseover', mouseover)
+    target.removeEventListener('mouseenter', mouseenter)
     target.removeEventListener('mouseleave', mouseleave)
   }
 }


### PR DESCRIPTION
When my target has descendants. Such as:
```jsx
<div v-popover:tooltip="'first name, last name'">
    <span>first name</span>
    <span>last name</span>
</div>
```
I found the event is `mouseover`,  and I leave first `span` to second `span`. The `showEventListener` will be triggered. and `this.visiable` is `true`. So the `popover` will be hidden.
https://github.com/euvl/vue-js-popover/blob/8b4568fdc5c594e1e72ed645ea332e4d81b8cf75/src/Popover.vue#L99-L103