### PR TITLE
Limit FOUT when first rendering <popover>

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -179,6 +179,10 @@ export default {
 <style lang="scss">
 $pointer-size: 6px;
 
+popover {
+  display: none;
+}
+
 .vue-popover {
   display: block;
   position: absolute;


### PR DESCRIPTION
When the component is first being rendered, but before the Vue app has mounted and finished initializing, the `<popover>` element is present in the DOM. Thus, the browser will render it. This results in a Flash Of Unstyled Text (FOUT), of sorts, where the contents of the `<popover>` appear, and are then removed. Adding a this CSS rule will shorten, an in cases where the stylesheets are already parsed and loaded, eliminate that flash.